### PR TITLE
fixed the issue of handling init errors in Firefox

### DIFF
--- a/binding/web/template/package.json
+++ b/binding/web/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@picovoice/cobra-web-worker",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Cobra library for web browsers (via WebAssembly)",
   "author": "Picovoice Inc",
   "license": "Apache-2.0",

--- a/binding/web/template/src/cobra_worker.ts
+++ b/binding/web/template/src/cobra_worker.ts
@@ -23,7 +23,7 @@ let cobraEngine: CobraEngine | null = null;
 async function init(accessKey: string, start = true): Promise<void> {
   try {
     cobraEngine = await Cobra.create(accessKey);
-    const cobraReadyMessage = {
+    const cobraReadyMessage: CobraWorkerResponseReady = {
       command: 'cobra-ready',
     };
     paused = !start;
@@ -31,11 +31,11 @@ async function init(accessKey: string, start = true): Promise<void> {
     postMessage(cobraReadyMessage, undefined);
   } catch (error) {
     const errorMessage = String(error);
-    const octopusFailedMessage = {
+    const cobraFailedMessage: CobraWorkerResponseFailed = {
       command: 'cobra-failed',
       message: errorMessage,
     };
-    postMessage(octopusFailedMessage, undefined);
+    postMessage(cobraFailedMessage, undefined);
   }
 }
 

--- a/binding/web/template/src/cobra_worker.ts
+++ b/binding/web/template/src/cobra_worker.ts
@@ -21,21 +21,21 @@ let paused = true;
 let cobraEngine: CobraEngine | null = null;
 
 async function init(accessKey: string, start = true): Promise<void> {
-  let cobraReadyMessage: CobraWorkerResponseReady | CobraWorkerResponseFailed;
   try {
     cobraEngine = await Cobra.create(accessKey);
-    cobraReadyMessage = {
+    const cobraReadyMessage = {
       command: 'cobra-ready',
     };
     paused = !start;
     // @ts-ignore
     postMessage(cobraReadyMessage, undefined);
   } catch (error) {
-    cobraReadyMessage = {
+    const errorMessage = String(error);
+    const octopusFailedMessage = {
       command: 'cobra-failed',
-      message: error as string,
+      message: errorMessage,
     };
-    postMessage(cobraReadyMessage, undefined);
+    postMessage(octopusFailedMessage, undefined);
   }
 }
 

--- a/binding/web/template/src/cobra_worker.ts
+++ b/binding/web/template/src/cobra_worker.ts
@@ -27,15 +27,16 @@ async function init(accessKey: string, start = true): Promise<void> {
     cobraReadyMessage = {
       command: 'cobra-ready',
     };
+    paused = !start;
+    // @ts-ignore
+    postMessage(cobraReadyMessage, undefined);
   } catch (error) {
     cobraReadyMessage = {
       command: 'cobra-failed',
       message: error as string,
     };
+    postMessage(cobraReadyMessage, undefined);
   }
-  paused = !start;
-  // @ts-ignore
-  postMessage(cobraReadyMessage, undefined);
 }
 
 async function process(inputFrame: Int16Array): Promise<void> {

--- a/demo/web/package.json
+++ b/demo/web/package.json
@@ -17,7 +17,7 @@
   "author": "Picovoice Inc",
   "license": "Apache-2.0",
   "dependencies": {
-    "@picovoice/cobra-web-worker": "^1.0.3",
+    "@picovoice/cobra-web-worker": "^1.0.4",
     "@picovoice/web-voice-processor": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The main change is 'const errorMessage = String(error);', firefox has some issue sending the error as is and `error as string` is just for typescript